### PR TITLE
Proposing Gov Cloud note for the Azure AD GitHub SAML integration documentation

### DIFF
--- a/articles/active-directory/saas-apps/github-tutorial.md
+++ b/articles/active-directory/saas-apps/github-tutorial.md
@@ -27,6 +27,9 @@ To get started, you need the following items:
 * An Azure AD subscription. If you don't have a subscription, you can get a [free account](https://azure.microsoft.com/free/).
 * A GitHub organization created in [GitHub Enterprise Cloud](https://help.github.com/articles/github-s-products/#github-enterprise), which requires the [GitHub Enterprise billing plan](https://help.github.com/articles/github-s-billing-plans/#billing-plans-for-organizations).
 
+> [!NOTE]
+> This integration is also available to use from Azure AD US Government Cloud environment. You can find this application in the Azure AD US Government Cloud Application Gallery and configure it in the same way as you do from public cloud.
+
 ## Scenario description
 
 In this tutorial, you configure and test Azure AD single sign-on in a test environment.


### PR DESCRIPTION
The Azure AD GitHub organization SAML provisioning tutorial (thttps://learn.microsoft.com/en-us/azure/active-directory/saas-apps/github-provisioning-tutorial) includes the following note:

> This integration is also available to use from Azure AD US Government Cloud environment. You can find this application in the Azure AD US Government Cloud Application Gallery and configure it in the same way as you do from public cloud.

Since https://learn.microsoft.com/en-us/azure/active-directory/saas-apps/github-tutorial is for the same Azure AD GitHub app (but for the SCIM provisioning integration), I'm proposing adding this note to that article as well. 

cc/ @hpsin